### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 An experimental [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that helps AI assistants connect to and retrieve information about duyet. This server provides access to information primarily available at [https://duyet.net](https://duyet.net), making it available directly to your AI assistant.
 
+<a href="https://glama.ai/mcp/servers/@duyet/duyet-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@duyet/duyet-mcp-server/badge" alt="Duyet Server MCP server" />
+</a>
+
 Usage: Update MCP server configuration in your AI assistant:
 
 ```json


### PR DESCRIPTION
This PR adds a badge for the [Duyet MCP Server](https://glama.ai/mcp/servers/@duyet/duyet-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@duyet/duyet-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@duyet/duyet-mcp-server/badge" alt="Duyet Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

## Summary by Sourcery

Documentation:
- Insert a clickable Glama badge snippet into the README to highlight the Duyet MCP Server listing